### PR TITLE
only download the MA and RI OSM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /mbta_otp.zip
-/us-northeast-latest.osm.pbf
+/*.osm.pbf
 /var/graphs/mbta/Graph.obj
 /var/graphs/mbta/MBTA_GTFS.zip
-/var/graphs/mbta/watershed.pbf
+/var/graphs/mbta/*.pbf

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
+
+# ensure we use Java 8; other versions have an issue building the graph:
+# https://groups.google.com/forum/#!topic/opentripplanner-users/pvtm3BSyS9g
+export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
+
 java -Xmx4G -jar otp-1.2.0-shaded.jar --build var/graphs/mbta/ --basePath var/

--- a/semaphore/build.sh
+++ b/semaphore/build.sh
@@ -2,12 +2,6 @@
 # should be run as ./semaphore/build.sh
 set -e
 
-# fetch osmconvert script needed to work with the PBF file
-# http://wiki.openstreetmap.org/wiki/Osmconvert#Linux
-mkdir -p ~/bin
-wget -O ~/bin/osmconvert http://m.m.i24.cc/osmconvert64
-chmod +x ~/bin/osmconvert
-
 ./update_pbf.sh
 ./update_gtfs.sh
 ./build.sh

--- a/update_gtfs.sh
+++ b/update_gtfs.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-wget -N https://s3.amazonaws.com/mbta-gtfs-s3/MBTA_GTFS.zip -O var/graphs/mbta/MBTA_GTFS.zip
+wget -N https://cdn.mbta.com/MBTA_GTFS.zip -O var/graphs/mbta/MBTA_GTFS.zip

--- a/update_pbf.sh
+++ b/update_pbf.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
-rm var/graphs/mbta/*.pbf us-northeast-latest.osm.pbf
-wget -nc https://download.geofabrik.de/north-america/us-northeast-latest.osm.pbf
-~/bin/osmconvert us-northeast-latest.osm.pbf -b=-73.619,41.206,-69.644,42.936 --drop-author -o=var/graphs/mbta/watershed.pbf
+rm var/graphs/mbta/*.pbf *.osm.pbf
+for filename in massachusetts-latest.osm.pbf rhode-island-latest.osm.pbf; do
+    wget -nc -P var/graphs/mbta http://download.geofabrik.de/north-america/us/$filename
+done

--- a/var/graphs/mbta/router-config.json
+++ b/var/graphs/mbta/router-config.json
@@ -4,14 +4,14 @@
     {
       "type": "real-time-alerts",
       "frequencySec": 30,
-      "url": "http://developer.mbta.com/lib/GTRTFS/Alerts/Alerts.pb",
+      "url": "https://cdn.mbta.com/realtime/Alerts.pb",
       "feedId": "1"
     },
     {
       "type": "stop-time-updater",
       "frequencySec": 10,
       "sourceType": "gtfs-http",
-      "url": "http://developer.mbta.com/lib/GTRTFS/Alerts/TripUpdates.pb",
+      "url": "https://cdn.mbta.com/realtime/TripUpdates.pb",
       "feedId": "1"
     }
   ]


### PR DESCRIPTION
Getting the full northeast file was taking longer to download than Semaphore was giving us, making it impossible to deploy.