### PR TITLE
Changing value of maxTransferDistance parameter from 2000 to 750 meters

### DIFF
--- a/var/graphs/mbta/build-config.json
+++ b/var/graphs/mbta/build-config.json
@@ -1,5 +1,6 @@
 {
   "useTransfersTxt": true,
+  "useBothGtfsAndDistance": true,
   "parentStopLinking": true,
   "fetchElevationUS": false,
   "embedRouterConfig": false,

--- a/var/graphs/mbta/build-config.json
+++ b/var/graphs/mbta/build-config.json
@@ -3,6 +3,6 @@
   "parentStopLinking": true,
   "fetchElevationUS": false,
   "embedRouterConfig": false,
-  "maxTransferDistance": 2000,
+  "maxTransferDistance": 750,
   "staticParkAndRide": true
 }


### PR DESCRIPTION
Ticket: [Instead of transferring where the routes cross, the trip planner suggests transferring in Medford](https://app.asana.com/0/810933294009540/1109557837333469)

We're adding transfers, which are based on the distance (that is, not on GTFS transfers.txt), to the OTP Graph, so we need to tweak this parameter in order to exclude stops, which are too far away. 

Also adding `useBothGtfsAndDistance` variable introduced in https://github.com/mbta/OpenTripPlanner/pull/3