### PR TITLE
Adding 'set -e' option to CI scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 pushd OpenTripPlanner
 mvn -Dmaven.repo.local="${SEMAPHORE_CACHE_DIR}/.m2/" clean install -Dmaven.test.skip=true -Dgpg.skip -Dmaven.javadoc.skip=true

--- a/semaphore/integration_tests.sh
+++ b/semaphore/integration_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 export PIPENV_VERBOSITY=-1
 export PIPENV_CACHE_DIR=$SEMAPHORE_CACHE_DIR

--- a/semaphore/setup.sh
+++ b/semaphore/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # ensure we use Java 8; other versions have an issue building the graph:
 # https://groups.google.com/forum/#!topic/opentripplanner-users/pvtm3BSyS9g

--- a/tests.sh
+++ b/tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 pushd OpenTripPlanner
 mvn -Dmaven.repo.local="${SEMAPHORE_CACHE_DIR}/.m2/" clean test -Dgpg.skip -Dmaven.javadoc.skip=true

--- a/update_gtfs.sh
+++ b/update_gtfs.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # it's important for MBTA_GFTS to be first file in the folder,
 # otherwise realtime alerts won't work: https://github.com/mbta/OpenTripPlanner/pull/8

--- a/update_pbf.sh
+++ b/update_pbf.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-rm var/graphs/mbta/*.pbf *.osm.pbf
+rm -rf var/graphs/mbta/*.pbf
 for filename in massachusetts-latest.osm.pbf rhode-island-latest.osm.pbf; do
     wget -nc -P var/graphs/mbta http://download.geofabrik.de/north-america/us/$filename
 done

--- a/update_pbf.sh
+++ b/update_pbf.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 rm var/graphs/mbta/*.pbf *.osm.pbf
 for filename in massachusetts-latest.osm.pbf rhode-island-latest.osm.pbf; do
     wget -nc -P var/graphs/mbta http://download.geofabrik.de/north-america/us/$filename


### PR DESCRIPTION
Ticket: [OTP brittle test / wrong CI configuration](https://app.asana.com/0/810933294009540/1134701410333054/f)

This PR is only about fixing the scripts so they fail when maven goals fail. Testing fixes are going to be in separate PR in OTP repo. 