### PR TITLE
Deploy to prod on merge to master

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,12 +6,12 @@ name: Push changes
 on:
   push:
     branches:
-      - 'otp2-upgrade'
+      - 'master'
 
 jobs:
   deploy:
-    name: Deploy to local
+    name: Deploy to prod
     uses: ./.github/workflows/deploy.yml
     with:
-      deployment-env: local
+      deployment-env: prod
     secrets: inherit


### PR DESCRIPTION
### Summary

*Ticket:* [Get the otp-deploy repo unarchived and ready to deploy OTP2](https://app.asana.com/0/1204355099788517/1205077941778169/f)

This makes OTP deploy any time changes are merged to master, rather than the dev branch.

### Testing

This worked as expected with the otp2-upgrade branch, and prod deploy worked manually.
