### PR TITLE
Fix: Add contents-read permissions to workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy to ECS
 
 permissions:
   id-token: write
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
### Summary

Small fix to add `contents: read` to workflow permissions block. This was identified by Infra as a process improvement after the initial work was done on this task. 
