### PR TITLE
test updated build-push-ecr action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
           echo "repo=$REPO" >> $GITHUB_OUTPUT
           echo "commit=$COMMIT" >> $GITHUB_OUTPUT
         
-      - uses: mbta/actions/build-push-ecr@v2
+      - uses: mbta/actions/build-push-ecr@mth-docker-build-push
         id: build-push
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}


### PR DESCRIPTION
### Summary

*Ticket:* none

I'm working on [updating `mbta/actions/build-push-ecr`](https://github.com/mbta/actions/pull/41) to be based on [`docker/build-push-action`](https://github.com/marketplace/actions/build-and-push-docker-images) and adding caching via GitHub Actions. Since the `docker-additional-args` input allows for arbitrary command line flags, but `docker/build-push-action` doesn't expose such a mechanism, maintaining backwards compatibility is something of an adventure. Conveniently, this repo and Skate are the only places that pass `docker-additional-args`, and both of them only use `--build-arg`, so I've done some creative shell scripting to translate into the more straightforward build args `docker/build-push-action` expects. There'll be an actual migration process eventually, but in the short term, I need to be confident my creative shell scripting actually works, which means running my branch of `mbta/actions/build-push-ecr` to deploy this repo to some dev instance so we can validate that the build args are going in as specified.

This PR should not be merged, just temporarily deployed to a dev environment long enough to validate that the build args and additional tags get applied correctly. After https://github.com/mbta/actions/pull/41 is merged, I'll come back and make a separate PR to actually migrate to the new build args format so I can get rid of the creative shell scripting.

### Testing

I've checked the new action's shell scripting setup locally and confirmed that it should in theory work.
