### PR TITLE
feat: enable `removeItinerariesWithSameRoutesAndStops`

### DIFF
--- a/var/router-config.json
+++ b/var/router-config.json
@@ -1,7 +1,8 @@
 {
   "routingDefaults": {
     "itineraryFilters": {
-      "accessibilityScore": true
+      "accessibilityScore": true,
+      "removeItinerariesWithSameRoutesAndStops": true
     }
   },
   "updaters": [
@@ -18,10 +19,10 @@
       "feedId": "mbta-ma-us"
     },
     {
-      "type" : "vehicle-positions",
-      "frequency" : "1m",
-      "url" : "https://cdn.mbta.com/realtime/VehiclePositions.pb",
-      "feedId" : "mbta-ma-us"
+      "type": "vehicle-positions",
+      "frequency": "1m",
+      "url": "https://cdn.mbta.com/realtime/VehiclePositions.pb",
+      "feedId": "mbta-ma-us"
     }
   ]
 }


### PR DESCRIPTION
### Summary

*Ticket:* [Trip planner backend changes](https://app.asana.com/0/385363666817452/1206301319901542/f)

![image](https://github.com/mbta/otp-deploy/assets/2136286/099fcf42-123b-4e80-825b-1a9573d6be00)

This change ensures a variety of results shown instead of the same trip shown five times! I'm so glad OTPv2.2 added this flag!

### Testing

Here's what the new result for the above query looks like. Three different itineraries! :tada:

<img width="954" alt="image" src="https://github.com/mbta/otp-deploy/assets/2136286/44f2a527-eea5-4446-9225-c61210348056">

