### PR TITLE
feat: enable itinerary `numberOfTransfers`

### DIFF
--- a/.envrc.global
+++ b/.envrc.global
@@ -6,4 +6,5 @@
 # An https URL must be used for the repo, or docker won't be able to clone it.
 export OTP_REPO=https://github.com/opentripplanner/OpenTripPlanner.git
 # The commit can be either a hash or a branch, but only hashes should be used in prod.
-export OTP_COMMIT=0535840c494b17a520ac0b7f595822acb1cccad3
+# This is somewhere after 2.4.0 but before 2.5.0, in order to use the numberOfTransfers field on Itinerary
+export OTP_COMMIT=5da22683573f94b5d32f4711e29ff2252c28fcac

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-java adoptopenjdk-17.0.7+7
+java adoptopenjdk-21.0.2+13.0.LTS
 maven 3.9.2
 direnv 2.32.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl git ca-cer
 WORKDIR /java/
 
 # Download the JRE for copying to the image to run the OTP server
-RUN curl -Lo jre17.tar.gz https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jre_x64_linux_hotspot_17.0.7_7.tar.gz
-RUN tar xvf jre17.tar.gz && rm jre17.tar.gz
+RUN curl -Lo jre21.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_x64_linux_hotspot_21.0.2_13.tar.gz
+RUN tar xvf jre21.tar.gz && rm jre21.tar.gz
 
 # Download the JDK and maven and add them to path for building OTP
-RUN curl -Lo jdk17.tar.gz https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.7_7.tar.gz
-RUN tar xvf jdk17.tar.gz && rm jdk17.tar.gz
-ENV JAVA_HOME=/java/jdk-17.0.7+7/
+RUN curl -Lo jdk21.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_x64_linux_hotspot_21.0.2_13.tar.gz
+RUN tar xvf jdk21.tar.gz && rm jdk21.tar.gz
+ENV JAVA_HOME=/java/jdk-21.0.2+13/
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
 RUN curl -Lo maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
@@ -42,10 +42,10 @@ USER otp
 COPY --from=builder --chown=otp:otp /build/otp/target/otp-*-shaded.jar /dist/otp.jar
 COPY --from=builder --chown=otp:otp /build/var/graph.obj /dist/var/
 COPY --from=builder --chown=otp:otp /build/var/*.json /dist/var/
-COPY --from=builder --chown=otp:otp /java/jdk-17.0.7+7-jre /java/jdk-17.0.7+7-jre
+COPY --from=builder --chown=otp:otp /java/jdk-21.0.2+13-jre /java/jdk-21.0.2+13-jre
 
 # Set the default java install to the JRE that was copied into the image rather than the JDK
-ENV JAVA_HOME="/java/jdk-17.0.7+7-jre"
+ENV JAVA_HOME="/java/jdk-21.0.2+13-jre"
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
 ENV PORT=5000


### PR DESCRIPTION

### Summary

Part of [Trip planner itinerary tagging: implement tie-breaking & new "most direct" tag (tie-breaking with fallback)](https://app.asana.com/0/555089885850811/1206595270365336/f)

- it hasn't been released officially but this later commit has support for fetching the itinerary's [`numberOfTransfers`](https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/Itinerary#ccs-0.g2gkbmgazyl)
- bump java version so that OTP builds without error

### Testing

Fetching itineraries locally with `numberOfTransfers` no longer raises a GraphQL `ValidationError` with this!
