### PR TITLE
chore: update OpenTripPlanner to v2.5

### DIFF
--- a/.envrc.global
+++ b/.envrc.global
@@ -9,3 +9,5 @@ export OTP_REPO=https://github.com/opentripplanner/OpenTripPlanner.git
 
 # This is somewhat after 2.5.0
 export OTP_COMMIT=69dca4ee82fc7b8fd96c610b176e40d750007841
+
+export MBTA_GTFS_URL="${MBTA_GTFS_URL:-https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip}"

--- a/.envrc.global
+++ b/.envrc.global
@@ -6,5 +6,6 @@
 # An https URL must be used for the repo, or docker won't be able to clone it.
 export OTP_REPO=https://github.com/opentripplanner/OpenTripPlanner.git
 # The commit can be either a hash or a branch, but only hashes should be used in prod.
-# This is somewhere after 2.4.0 but before 2.5.0, in order to use the numberOfTransfers field on Itinerary
-export OTP_COMMIT=5da22683573f94b5d32f4711e29ff2252c28fcac
+
+# This is somewhat after 2.5.0
+export OTP_COMMIT=69dca4ee82fc7b8fd96c610b176e40d750007841

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 var/graph.obj
 var/*.zip
 var/*.pbf
+var/report
 *.jar
 
 .envrc.local
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN curl -Lo maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.2/bi
 RUN tar xvf maven.tar.gz && rm maven.tar.gz
 ENV PATH="/java/apache-maven-3.9.2/bin/:$PATH"
 
-# Download the latest GTFS and PBF files, then build OTP
 WORKDIR /build
 COPY . .
 
@@ -46,7 +45,7 @@ COPY --from=builder --chown=otp:otp /java/jdk-21.0.2+13-jre /java/jdk-21.0.2+13-
 # Set the default java install to the JRE that was copied into the image rather than the JDK
 ENV JAVA_HOME="/java/jdk-21.0.2+13-jre"
 ENV PATH="$JAVA_HOME/bin:$PATH"
-
+ENV MBTA_GTFS_URL="$MBTA_GTFS_URL"
 ENV PORT=5000
 EXPOSE $PORT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ COPY --from=builder --chown=otp:otp /java/jdk-21.0.2+13-jre /java/jdk-21.0.2+13-
 # Set the default java install to the JRE that was copied into the image rather than the JDK
 ENV JAVA_HOME="/java/jdk-21.0.2+13-jre"
 ENV PATH="$JAVA_HOME/bin:$PATH"
+
+ARG MBTA_GTFS_URL=https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip
 ENV MBTA_GTFS_URL="$MBTA_GTFS_URL"
 ENV PORT=5000
 EXPOSE $PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ WORKDIR /build
 COPY . .
 
 ARG MBTA_GTFS_URL=https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip
-RUN MBTA_GTFS_URL="$MBTA_GTFS_URL" ./scripts/update_gtfs.sh
-RUN ./scripts/update_pbf.sh
+ENV MBTA_GTFS_URL="$MBTA_GTFS_URL"
 
 ARG OTP_REPO
 ARG OTP_COMMIT

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ You'll need to clone this repo run the following from the project root:
 1. `asdf install`
 1. `direnv allow`
 1. `./scripts/update_gtfs.sh` - fetches latest MBTA and Massport GTFS data
-1. `./scripts/update_pbf.sh` - updates OpenStreetMap data
 1. `./scripts/build.sh` - packages OTP into a jar, then runs the OTP build process
 
 If you want to test with local GTFS changes, put a copy of your GTFS file (if you've built

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ You'll need to clone this repo run the following from the project root:
 
 1. `asdf install`
 1. `direnv allow`
-1. `./scripts/update_gtfs.sh` - fetches latest MBTA and Massport GTFS data
 1. `./scripts/build.sh` - packages OTP into a jar, then runs the OTP build process
 
 If you want to test with local GTFS changes, put a copy of your GTFS file (if you've built

--- a/scripts/update_gtfs.sh
+++ b/scripts/update_gtfs.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-curl -o var/mbta-ma-us.gtfs.zip "${MBTA_GTFS_URL:-"https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip"}"

--- a/scripts/update_gtfs.sh
+++ b/scripts/update_gtfs.sh
@@ -2,4 +2,3 @@
 set -e
 
 curl -o var/mbta-ma-us.gtfs.zip "${MBTA_GTFS_URL:-"https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip"}"
-curl -o var/massport-ma-us.gtfs.zip https://data.trilliumtransit.com/gtfs/massport-ma-us/massport-ma-us.zip

--- a/scripts/update_pbf.sh
+++ b/scripts/update_pbf.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-rm -rf var/*.pbf
-for filename in massachusetts-latest.osm.pbf rhode-island-latest.osm.pbf; do
-    curl --output-dir var/ -O http://download.geofabrik.de/north-america/us/$filename
-done

--- a/var/build-config.json
+++ b/var/build-config.json
@@ -5,6 +5,19 @@
   ],
   "dataImportReport": true,
   "embedRouterConfig": false,
+  "osm": [
+    {
+      "source": "https://download.geofabrik.de/north-america/us/massachusetts-latest.osm.pbf",
+      "timeZone": "America/New_York",
+      "osmTagMapping": "default"
+    },
+    {
+      "source": "https://download.geofabrik.de/north-america/us/rhode-island-latest.osm.pbf",
+      "timeZone": "America/New_York",
+      "osmTagMapping": "default"
+    }
+  ],
+  "osmCacheDataInMem": "true",
   "osmDefaults": {
     "timeZone": "America/New_York"
   },

--- a/var/build-config.json
+++ b/var/build-config.json
@@ -1,5 +1,9 @@
 {
-  "boardingLocationTags": ["gtfs:stop_id", "ref"],
+  "boardingLocationTags": [
+    "gtfs:stop_id",
+    "ref"
+  ],
+  "dataImportReport": true,
   "embedRouterConfig": false,
   "osmDefaults": {
     "timeZone": "America/New_York"

--- a/var/build-config.json
+++ b/var/build-config.json
@@ -8,6 +8,18 @@
   "osmDefaults": {
     "timeZone": "America/New_York"
   },
+  "transitFeeds": [
+    {
+      "type": "gtfs",
+      "feedId": "massport-ma-us",
+      "source": "https://data.trilliumtransit.com/gtfs/massport-ma-us/massport-ma-us.zip"
+    },
+    {
+      "type": "gtfs",
+      "feedId": "mbta-ma-us",
+      "source": "mbta-ma-us.gtfs.zip"
+    }
+  ],
   "transferRequests": [
     {
       "modes": "WALK"

--- a/var/build-config.json
+++ b/var/build-config.json
@@ -30,7 +30,7 @@
     {
       "type": "gtfs",
       "feedId": "mbta-ma-us",
-      "source": "mbta-ma-us.gtfs.zip"
+      "source": "${MBTA_GTFS_URL}"
     }
   ],
   "transferRequests": [


### PR DESCRIPTION
### Summary

*Ticket:* [Investigate: Trip Planner does not appear to be using real-time data](https://app.asana.com/0/555089885850811/1206364898309485/f)

I missed updating this when OTP2.5 came out so here we are! I also wanted to enable the data import report so I did.
Separately I noticed that OTP itself can handle loading data over HTTP, so I added that configuration.

### Testing

Been playing around with this locally for a week or so. The new OTP version actually changes the GraphQL API interface slightly, so there are corresponding changes for [open_trip_planner_client](https://github.com/thecristen/open_trip_planner_client/compare/v0.6.4...v0.7.0) and [dotcom](https://github.com/mbta/dotcom/pull/1982).
