### PR TITLE
feat: use run-name for deployment environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 # Invoke deploy to ECS
 name: Deploy to ECS
+run-name: Deploy to ${{ inputs.deployment-env }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
### Summary

*Ticket:* [use run-name for OTP deploys](https://app.asana.com/0/555089885850811/1207909575558906/f)

We can see what environment is being deployed to in the list of runs, see: https://github.com/mbta/otp-deploy/actions/runs/10116246128