### PR TITLE
Currently, accessibility is not enabled, this PR enables it

### DIFF
--- a/var/router-config.json
+++ b/var/router-config.json
@@ -3,6 +3,9 @@
     "itineraryFilters": {
       "accessibilityScore": true,
       "removeItinerariesWithSameRoutesAndStops": true
+    },
+    "wheelchairAccessibility": {
+      "enabled": true
     }
   },
   "updaters": [


### PR DESCRIPTION
https://app.asana.com/0/555089885850811/1207601171393147/f

Though it isn't mentioned in the wheelchair accessibility docs, there is a config named 'enabled' that is false by default. We have to set it to true to check trips against accessibility.
