### PR TITLE
Turn accessibility off

### DIFF
--- a/var/router-config.json
+++ b/var/router-config.json
@@ -3,9 +3,6 @@
     "itineraryFilters": {
       "accessibilityScore": true,
       "removeItinerariesWithSameRoutesAndStops": true
-    },
-    "wheelchairAccessibility": {
-      "enabled": true
     }
   },
   "updaters": [


### PR DESCRIPTION
Apparently, 'enabling' wheelchair accessibility means only returning accessible routes.