### PR TITLE
cleanup: Default `REMOVE_ITINERARIES_WITH_SAME_ROUTES_AND_STOPS` to `false`

### DIFF
--- a/.envrc.global
+++ b/.envrc.global
@@ -13,7 +13,7 @@ export OTP_COMMIT=69dca4ee82fc7b8fd96c610b176e40d750007841
 export MBTA_GTFS_URL="${MBTA_GTFS_URL:-https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip}"
 
 export MAX_SEARCH_WINDOW=PT24H
-export REMOVE_ITINERARIES_WITH_SAME_ROUTES_AND_STOPS=true
+export REMOVE_ITINERARIES_WITH_SAME_ROUTES_AND_STOPS=false
 export SEARCH_WINDOW=PT24H
 export URL_ALERTS=https://cdn.mbta.com/realtime/Alerts.pb
 export URL_TRIP_UPDATES=https://cdn.mbta.com/realtime/TripUpdates.pb

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
         name: Set default config
         run: |
           echo "MAX_SEARCH_WINDOW=PT24H" >> $GITHUB_OUTPUT
-          echo "REMOVE_ITINERARIES_WITH_SAME_ROUTES_AND_STOPS=true" >> $GITHUB_OUTPUT
+          echo "REMOVE_ITINERARIES_WITH_SAME_ROUTES_AND_STOPS=false" >> $GITHUB_OUTPUT
           echo "SEARCH_WINDOW=PT24H" >> $GITHUB_OUTPUT
           echo "URL_ALERTS=https://cdn.mbta.com/realtime/Alerts.pb" >> $GITHUB_OUTPUT
           echo "URL_TRIP_UPDATES=https://cdn.mbta.com/realtime/TripUpdates.pb" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Since we released the new trip planner, `REMOVE_ITINERARIES_WITH_SAME_ROUTES_AND_STOPS` has been set to `false` [in all environments](https://github.com/mbta/devops/blob/086aba890843e28c7e16e1781d41db784847ff6b/terraform/modules/app-otp2/variables.tf#L47-L51). Let's have a clean `master` branch for this repo behave the same as production!

(Possible follow-up, or even enhancement to this PR: Could we just get rid of the variable entirely, and hard-code it to `false` closer to where it's used? Should we?)

---

No ticket