### PR TITLE
feat: allow trips and stops of unknown wheelchair-accessibility

### DIFF
--- a/var/router-config.json
+++ b/var/router-config.json
@@ -4,7 +4,26 @@
       "accessibilityScore": true,
       "removeItinerariesWithSameRoutesAndStops": "${REMOVE_ITINERARIES_WITH_SAME_ROUTES_AND_STOPS}"
     },
-    "searchWindow": "${SEARCH_WINDOW}"
+    "searchWindow": "${SEARCH_WINDOW}",
+    "wheelchairAccessibility": {
+      "trip": {
+        "onlyConsiderAccessible": false,
+        "unknownCost": 600,
+        "inaccessibleCost": 3600
+      },
+      "stop": {
+        "onlyConsiderAccessible": false,
+        "unknownCost": 600,
+        "inaccessibleCost": 3600
+      },
+      "elevator": {
+        "onlyConsiderAccessible": false
+      },
+      "inaccessibleStreetReluctance": 25,
+      "maxSlope": 0.08333,
+      "slopeExceededReluctance": 50,
+      "stairsReluctance": 25
+    }
   },
   "transit": {
     "maxSearchWindow": "${MAX_SEARCH_WINDOW}"


### PR DESCRIPTION
Just followed the guidance in the docs: https://docs.opentripplanner.org/en/latest/Accessibility/?h=wheel#configuration
Notably the build config already had the suggested changes, so only needed to adjust the router config for completeness.

### Summary

*Ticket:* [Open Trip Planner: set onlyConsiderAccessible to false](https://app.asana.com/0/555089885850811/1209939784083534/f)

In Dotcom's trip planner we'd like to eventually be able to show both accessible and inaccessible results. However, OTP will omit inaccessible results entirely with the current configuration, if using `wheelchair: true`. This PR fixes that, so that using `wheelchair: true` will no longer exclusively return `accessibilityScore: 1.0` itineraries.

### Testing

Ran locally and played around with itineraries around Brookline. Can verify that now we get a mix of `accessibilityScore` values (whereas before OTP would suppress results < 1.0).

<img width="518" alt="image" src="https://github.com/user-attachments/assets/7765fa8f-1118-442f-a4a0-95c104d31285" />

