### PR TITLE
feat: use the hosted disruption-free MBTA GTFS feed

### DIFF
--- a/var/build-config.json
+++ b/var/build-config.json
@@ -35,7 +35,7 @@
     {
       "type": "gtfs",
       "feedId": "mbta-ma-us-initial",
-      "source": "../disruption-free-for-dotcom.zip"
+      "source": "https://mbta-gtfs-s3.s3.amazonaws.com/MBTA_GTFS_initial.zip"
     }
   ],
   "transferRequests": [


### PR DESCRIPTION
### Summary

*Ticket:* [Connect OTP to the hosted disruption-free GTFS feed](https://app.asana.com/1/15492006741476/project/385363666817452/task/1211093719240086?focus=true)

Replace the source with the hosted version. Thanks Transit Data 🥰 

### Testing

Going to deploy it somewhere to verify it builds and that Dotcom's trip planner shows unavailable trips for the upcoming rating (update: it's on dev-blue)

There are no next-rating planned work in dev-blue (I think?) but the current situation looks good: 
<img width="1193" height="659" alt="image" src="https://github.com/user-attachments/assets/fe8c5ddd-5fdf-43ba-9384-eb769e23fa1a" />

