### PR TITLE
fix: build using locally-hosted OSM data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ where you can try out trip plans.
 
 If you're not seeing any results from the current day, double check that you don't have an old GTFS file, if the
 schedules don't include the requested date, OTP can't plan a trip for it. If OTP doesn't seem to include recent OSM
-changes that you expect it have, double check that the `.pbf` file is up to date, and that the changeset is included
-in the latest [Geofabrik update](http://download.geofabrik.de/north-america/us/massachusetts.html). These updates only
-happen once per day, so you may need to wait up to 24 hours to pull any OSM changes you've made.
+changes that you expect it have, double check that the `.pbf` file is up to date. We download files from [Geofabrik](http://download.geofabrik.de/north-america/us/massachusetts.html),
+which gets updates only once per day, so you may need to wait up to 24 hours to pull any OSM changes you've made.
 
 ## Updating OTP from upstream
 

--- a/var/build-config.json
+++ b/var/build-config.json
@@ -7,12 +7,12 @@
   "embedRouterConfig": false,
   "osm": [
     {
-      "source": "https://download.geofabrik.de/north-america/us/massachusetts-latest.osm.pbf",
+      "source": "https://mbta-map-tiles.s3.us-east-1.amazonaws.com/data/osm/massachusetts-latest.osm.pbf",
       "timeZone": "America/New_York",
       "osmTagMapping": "default"
     },
     {
-      "source": "https://download.geofabrik.de/north-america/us/rhode-island-latest.osm.pbf",
+      "source": "https://mbta-map-tiles.s3.us-east-1.amazonaws.com/data/osm/rhode-island-latest.osm.pbf",
       "timeZone": "America/New_York",
       "osmTagMapping": "default"
     }


### PR DESCRIPTION
### Summary

Now that we're downloading Geofabrik data into our own S3 bucket, we can read from that instead of pulling from Geofabrik.

### Testing

Going to test with a deploy.
