### PR TITLE
chore: upgrade OpenTripPlanner to v2.9

### DIFF
--- a/.envrc.global
+++ b/.envrc.global
@@ -7,11 +7,8 @@
 export OTP_REPO=https://github.com/opentripplanner/OpenTripPlanner.git
 # The commit can be either a hash or a branch, but only hashes should be used in prod.
 
-# This is somewhat after 2.7.0. This commit will let us use the
-# deprecated "plan" while migrating to the newer "planConnection" (after it
-# regained the ability to filter transit agencies, which is required for
-# unavailable trips to be processed correctly)
-export OTP_COMMIT=cf64ae34bd901bca922e3799b76ebe81e81bc6e2
+# This is somewhat after 2.9.0. Includes an update to Java 25!
+export OTP_COMMIT=1c3d0cf02ddb9a7a738f9773ad2837460e4199a1
 
 export MBTA_GTFS_URL="${MBTA_GTFS_URL:-https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip}"
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-java adoptopenjdk-21.0.2+13.0.LTS
-maven 3.9.2
+java temurin-25.0.4+7.0.LTS
+maven 3.9.9
 direnv 2.35.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 java adoptopenjdk-21.0.2+13.0.LTS
 maven 3.9.2
-direnv 2.32.3
+direnv 2.35.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl git ca-cer
 WORKDIR /java/
 
 # Download the JRE for copying to the image to run the OTP server
-RUN curl -Lo jre21.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_x64_linux_hotspot_21.0.2_13.tar.gz
-RUN tar xvf jre21.tar.gz && rm jre21.tar.gz
+RUN curl -Lo jre25.tar.gz https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jre_x64_linux_hotspot_25.0.4_7.tar.gz
+RUN tar xvf jre25.tar.gz && rm jre25.tar.gz
 
 # Download the JDK and maven and add them to path for building OTP
-RUN curl -Lo jdk21.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_x64_linux_hotspot_21.0.2_13.tar.gz
-RUN tar xvf jdk21.tar.gz && rm jdk21.tar.gz
-ENV JAVA_HOME=/java/jdk-21.0.2+13/
+RUN curl -Lo jdk25.tar.gz https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_linux_hotspot_25.0.4_7.tar.gz
+RUN tar xvf jdk25.tar.gz && rm jdk25.tar.gz
+ENV JAVA_HOME=/java/jdk-25.0.4+7/
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
-RUN curl -Lo maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
+RUN curl -Lo maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
 RUN tar xvf maven.tar.gz && rm maven.tar.gz
-ENV PATH="/java/apache-maven-3.9.2/bin/:$PATH"
+ENV PATH="/java/apache-maven-3.9.9/bin/:$PATH"
 
 WORKDIR /build
 COPY . .
@@ -54,10 +54,10 @@ USER otp
 COPY --from=builder --chown=otp:otp /build/otp/otp-shaded/target/otp-shaded-*-SNAPSHOT.jar /dist/otp.jar
 COPY --from=builder --chown=otp:otp /build/var/graph.obj /dist/var/
 COPY --from=builder --chown=otp:otp /build/var/*.json /dist/var/
-COPY --from=builder --chown=otp:otp /java/jdk-21.0.2+13-jre /java/jdk-21.0.2+13-jre
+COPY --from=builder --chown=otp:otp /java/jdk-25.0.4+7-jre /java/jdk-25.0.4+7-jre
 
 # Set the default java install to the JRE that was copied into the image rather than the JDK
-ENV JAVA_HOME="/java/jdk-21.0.2+13-jre"
+ENV JAVA_HOME="/java/jdk-25.0.4+7-jre"
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
 ARG MBTA_GTFS_URL=https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip


### PR DESCRIPTION
### Summary

*Ticket:* [🗺️ [Quarterly] Upgrade OpenTripPlanner ](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210163092602211?focus=true)

We missed a couple quarters but now it's here! Going from 2.7 to 2.9 (just in time for 2.10 to likely come out this fall).

Note this also involves some tooling upgrades -- enjoy Java 25!

### Testing

Ran it locally and pointed Dotcom's trip planner to it, and everything seems to be in working order.
We'll deploy it to a staging server and verify there too.
